### PR TITLE
first modifications to enable the switch repo to be used standalone

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -1,4 +1,27 @@
 ACLOCAL_AMFLAGS = ${ACLOCAL_FLAGS} -I m4
-# P4FLAGS = -I .
 
-SUBDIRS = switchapi switchsai switchlink
+if WITH_BMV2
+MAYBE_BMV2 = bmv2
+endif
+
+SUBDIRS = $(MAYBE_BMV2) switchapi switchsai switchlink .
+
+bin_PROGRAMS =
+
+if WITH_BMV2
+bin_PROGRAMS += bmswitchp4_drivers
+bmswitchp4_drivers_CPPFLAGS = $(AM_CPPFLAGS)
+bmswitchp4_drivers_CPPFLAGS += -DBMV2
+bmswitchp4_drivers_CPPFLAGS += -I$(top_srcdir)/bmv2/p4_pd
+bmswitchp4_drivers_CPPFLAGS += -I$(BM_PDFIXED_PATH)/
+bmswitchp4_drivers_LDADD = \
+@builddir@/switchlink/libswitchlink.la \
+@builddir@/switchsai/libbmswitchsai.la \
+@builddir@/switchapi/libbmswitchapi.la \
+@builddir@/bmv2/libbmpd.la \
+@builddir@/bmv2/libbmpdthrift.la \
+-lbmpdfixed -lbmpdfixedthrift -lthrift
+bmswitchp4_drivers_SOURCES = \
+@srcdir@/bmv2/bmv2_init.c \
+@srcdir@/bmv2/main.c
+endif

--- a/Makefile.am
+++ b/Makefile.am
@@ -4,7 +4,19 @@ if WITH_BMV2
 MAYBE_BMV2 = bmv2
 endif
 
-SUBDIRS = $(MAYBE_BMV2) switchapi switchsai switchlink .
+if WITH_SWITCHAPI
+MAYBE_SWITCHAPI = switchapi
+endif
+
+if WITH_SWITCHSAI
+MAYBE_SWITCHSAI = switchsai
+endif
+
+if WITH_SWITCHLINK
+MAYBE_SWITCHLINK = switchlink
+endif
+
+SUBDIRS = $(MAYBE_BMV2) $(MAYBE_SWITCHAPI) $(MAYBE_SWITCHSAI) $(MAYBE_SWITCHLINK) .
 
 bin_PROGRAMS =
 

--- a/Makefile.am
+++ b/Makefile.am
@@ -19,21 +19,29 @@ endif
 SUBDIRS = $(MAYBE_BMV2) $(MAYBE_SWITCHAPI) $(MAYBE_SWITCHSAI) $(MAYBE_SWITCHLINK) .
 
 bin_PROGRAMS =
+lib_LTLIBRARIES =
 
 if WITH_BMV2
-bin_PROGRAMS += bmswitchp4_drivers
-bmswitchp4_drivers_CPPFLAGS = $(AM_CPPFLAGS)
-bmswitchp4_drivers_CPPFLAGS += -DBMV2
-bmswitchp4_drivers_CPPFLAGS += -I$(top_srcdir)/bmv2/p4_pd
-bmswitchp4_drivers_CPPFLAGS += -I$(BM_PDFIXED_PATH)/
-bmswitchp4_drivers_LDADD = \
+AM_CPPFLAGS += -DBMV2
+AM_CPPFLAGS += -I$(top_srcdir)/bmv2/p4_pd
+AM_CPPFLAGS += -I$(BM_PDFIXED_PATH)
+
+lib_LTLIBRARIES += libbmswitchp4.la
+libbmswitchp4_la_CPPFLAGS = $(AM_CPPFLAGS)
+libbmswitchp4_la_LIBADD = \
 @builddir@/switchlink/libswitchlink.la \
 @builddir@/switchsai/libbmswitchsai.la \
 @builddir@/switchapi/libbmswitchapi.la \
 @builddir@/bmv2/libbmpd.la \
 @builddir@/bmv2/libbmpdthrift.la \
 -lbmpdfixed -lbmpdfixedthrift -lthrift
+libbmswitchp4_la_SOURCES = \
+@srcdir@/bmv2/bmv2_init.c
+
+bin_PROGRAMS += bmswitchp4_drivers
+bmswitchp4_drivers_CPPFLAGS = $(AM_CPPFLAGS)
+bmswitchp4_drivers_LDADD = \
+libbmswitchp4.la
 bmswitchp4_drivers_SOURCES = \
-@srcdir@/bmv2/bmv2_init.c \
 @srcdir@/bmv2/main.c
 endif

--- a/bmv2/Makefile.am
+++ b/bmv2/Makefile.am
@@ -1,0 +1,157 @@
+ACLOCAL_AMFLAGS = ${ACLOCAL_FLAGS} -I m4
+
+pd_files = \
+p4_pd/src/pd.cpp \
+p4_pd/src/pd_learning.cpp \
+p4_pd/src/pd_meters.cpp \
+p4_pd/src/pd_counters.cpp \
+p4_pd/src/pd_tables.cpp \
+p4_pd/src/pd_ageing.cpp \
+p4_pd/src/pd_mirroring.cpp
+
+pd_headers = \
+p4_pd/pd/pd.h \
+p4_pd/pd/pd_learning.h \
+p4_pd/pd/pd_meters.h \
+p4_pd/pd/pd_counters.h \
+p4_pd/pd/pd_tables.h \
+p4_pd/pd/pd_types.h \
+p4_pd/pd/pd_mirroring.h
+
+pd_p4_IDL = p4_pd/thrift/p4_pd_rpc.thrift
+pd_p4_src = \
+$(builddir)/p4_pd/thrift-src/p4_pd_rpc_server.ipp \
+$(builddir)/p4_pd/thrift-src/pd_rpc_server.cpp \
+$(builddir)/p4_pd/thrift-src/pd_rpc_server.h
+
+P4_PATH = $(top_srcdir)/p4src/switch.p4
+P4_PREFIX = dc
+P4_NAME = switch
+P4_JSON_OUTPUT = $(P4_NAME).json
+
+# TODO: improve
+include $(top_srcdir)/p4src/p4_files.am
+
+pd_files.ts : $(p4_files)
+	@rm -f pd_files.tmp
+	@touch pd_files.tmp
+	PYTHONPATH=$(PYTHONPATH) $(P4C_BM) --pd $(builddir)/p4_pd/ --p4-prefix $(P4_PREFIX) --json $(builddir)/$(P4_JSON_OUTPUT) $(P4_PATH)
+	@mv -f pd_files.tmp $@
+$(pd_files) $(pd_p4_IDL) $(pd_p4_src) : pd_files.ts
+## Recover from the removal of $@
+	@if test -f $@; then :; else \
+	  trap 'rm -rf pd_files.lock pd_files.ts' 1 2 13 15; \
+## mkdir is a portable test-and-set
+	if mkdir pd_files.lock 2>/dev/null; then \
+## This code is being executed by the first process.
+	  rm -f pd_files.ts; \
+	  $(MAKE) $(AM_MAKEFLAGS) pd_files.ts; \
+	  result=$$?; rm -rf pd_files.lock; exit $$result; \
+	else \
+## This code is being executed by the follower processes.
+## Wait until the first process is done.
+	  while test -d pd_files.lock; do sleep 1; done; \
+## Succeed if and only if the first process succeeded.
+	    test -f pd_files.ts; \
+	  fi; \
+	fi
+
+pd_p4_thrift_files = \
+pd_thrift_gen/gen-cpp/p4_prefix0.cpp \
+pd_thrift_gen/gen-cpp/p4_prefix1.cpp \
+pd_thrift_gen/gen-cpp/p4_prefix2.cpp \
+pd_thrift_gen/gen-cpp/p4_prefix.h \
+pd_thrift_gen/gen-cpp/p4_pd_rpc_constants.cpp \
+pd_thrift_gen/gen-cpp/p4_pd_rpc_constants.h \
+pd_thrift_gen/gen-cpp/p4_pd_rpc_types.cpp \
+pd_thrift_gen/gen-cpp/p4_pd_rpc_types.h
+
+pd_thrift_files = $(pd_p4_thrift_files)
+
+pd_p4_py = pd_thrift_gen/gen-py/p4_pd_rpc/constants.py
+
+pd_thrift_files.ts: $(pd_files) $(pd_p4_IDL) $(pd_res_IDL)
+	@rm -f pd_thrift_files.tmp
+	@touch pd_thrift_files.tmp
+	$(THRIFT) -o $(builddir)/pd_thrift_gen/ -I $(BM_PDFIXED_PATH)/thrift/ --gen cpp -r $(pd_p4_IDL)
+	$(THRIFT) -o $(builddir)/pd_thrift_gen/ -I $(BM_PDFIXED_PATH)/thrift/ --gen py -r $(pd_p4_IDL)
+	mv -f pd_thrift_gen/gen-cpp/$(P4_PREFIX).h pd_thrift_gen/gen-cpp/p4_prefix.h
+	sed --in-place 's/include "$(P4_PREFIX).h"/include "p4_prefix.h"/' pd_thrift_gen/gen-cpp/$(P4_PREFIX).cpp
+	$(PYTHON) $(srcdir)/split_pd_thrift.py pd_thrift_gen/gen-cpp/$(P4_PREFIX).cpp pd_thrift_gen/gen-cpp/ 3
+	@mv -f pd_thrift_files.tmp $@
+$(pd_thrift_files): pd_thrift_files.ts
+## Recover from the removal of $@
+	@if test -f $@; then :; else \
+	  trap 'rm -rf pd_thrift_files.lock pd_thrift_files.ts' 1 2 13 15; \
+## mkdir is a portable test-and-set
+	if mkdir pd_thrift_files.lock 2>/dev/null; then \
+## This code is being executed by the first process.
+	  rm -f pd_thrift_files.ts; \
+	  $(MAKE) $(AM_MAKEFLAGS) pd_thrift_files.ts; \
+	  result=$$?; rm -rf pd_thrift_files.lock; exit $$result; \
+	else \
+## This code is being executed by the follower processes.
+## Wait until the first process is done.
+	  while test -d pd_thrift_files.lock; do sleep 1; done; \
+## Succeed if and only if the first process succeeded.
+	    test -f pd_thrift_files.ts; \
+	  fi; \
+	fi
+
+thrift_py_lzma = gen-py.tar.lz
+
+$(thrift_py_lzma) : $(pdfixed_thrift_files) $(pd_thrift_files)
+	tar --create -C pd_thrift_gen/ gen-py/ | lzma > $(thrift_py_lzma)
+
+nobase_data_DATA = $(thrift_py_lzma)
+
+# See
+# http://stackoverflow.com/questions/6395148/install-data-directory-tree-with-massive-number-of-files-using-automake
+
+install-data-hook:
+	cp $(P4_JSON_OUTPUT) $(DESTDIR)$(datadir)
+	cd $(DESTDIR)$(datadir); \
+	cat $(thrift_py_lzma) | unlzma | tar --list > uninstall_manifest.txt; \
+	cat $(thrift_py_lzma) | unlzma | tar --no-same-owner --extract; \
+	rm -f $(thrift_py_lzma); \
+	cat uninstall_manifest.txt | sed --expression='s/^\|$$/"/g' | xargs chmod a=rX,u+w
+
+uninstall-local:
+	rm $(DESTDIR)$(datadir)/$(P4_JSON_OUTPUT)
+	cd $(DESTDIR)$(datadir); \
+	cat uninstall_manifest.txt | sed --expression='s/ /\\ /g' | xargs rm -f; \
+	rm -f uninstall_manifest.txt
+
+
+BUILT_SOURCES = \
+$(pd_files) \
+$(pd_thrift_files) \
+$(thrift_py_lzma)
+
+nobase_pkginclude_HEADERS = \
+$(pd_headers) \
+p4_pd/thrift-src/pd_rpc_server.h
+
+lib_LTLIBRARIES = libbmpd.la libbmpdthrift.la
+
+libbmpd_la_SOURCES = \
+$(pd_files)
+
+libbmpdthrift_la_SOURCES = \
+$(pd_thrift_files) \
+p4_pd/thrift-src/pd_rpc_server.cpp
+
+AM_CPPFLAGS += -I$(BM_PDFIXED_PATH)/
+AM_CPPFLAGS += -I$(BM_PDFIXED_PATH)/src/
+AM_CPPFLAGS += -I$(BM_THRIFT_PATH)/
+AM_CPPFLAGS += -I$(builddir)/p4_pd/
+AM_CPPFLAGS += -I$(builddir)/pd_thrift_gen/gen-cpp/
+# AM_CPPFLAGS += -I$(builddir)/p4_pd/
+# AM_CPPFLAGS += -I$(top_builddir)/pdfixed/bmv2_thrift_gen/gen-cpp/
+
+AM_CXXFLAGS = --std=c++11
+
+CLEANFILES = $(BUILT_SOURCES) \
+pd_files.ts pd_thrift_files.ts \
+.bmv2-pd-sane
+

--- a/bmv2/Makefile.am
+++ b/bmv2/Makefile.am
@@ -132,7 +132,7 @@ nobase_pkginclude_HEADERS = \
 $(pd_headers) \
 p4_pd/thrift-src/pd_rpc_server.h
 
-lib_LTLIBRARIES = libbmpd.la libbmpdthrift.la
+noinst_LTLIBRARIES = libbmpd.la libbmpdthrift.la
 
 libbmpd_la_SOURCES = \
 $(pd_files)

--- a/bmv2/bmv2_init.c
+++ b/bmv2/bmv2_init.c
@@ -1,0 +1,95 @@
+/*
+Copyright 2013-present Barefoot Networks, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+#include <errno.h>
+#include <stdlib.h>
+#include <string.h>
+#include <stdio.h>
+
+#include <getopt.h>
+#include <assert.h>
+
+#include <pd/pd.h>
+#include <thrift-src/pdfixed_rpc_server.h>
+#include <thrift-src/pd_rpc_server.h>
+
+char *pd_server_str = NULL;
+
+/**
+ * The maximum number of ports to support:
+ * @fixme should be runtime parameter
+ */
+#define PORT_COUNT 256
+#define PD_SERVER_DEFAULT_PORT 9090
+
+/**
+ * Check an operation and return if there's an error.
+ */
+#define CHECK(op)                                                     \
+  do {                                                                \
+    int _rv;                                                          \
+    if ((_rv = (op)) < 0) {                                           \
+      fprintf(stderr, "%s: ERROR %d at %s:%d",                        \
+              #op, _rv, __FILE__, __LINE__);                          \
+      return _rv;                                                     \
+    }                                                                 \
+  } while (0)
+
+#ifdef SWITCHLINK_ENABLE
+extern int switchlink_init(void);
+#endif /* SWITCHLINK_ENABLE */
+
+#ifdef SWITCHAPI_ENABLE
+extern int switch_api_init(int device, unsigned int num_ports);
+extern int start_switch_api_rpc_server(void);
+extern int start_switch_api_packet_driver(void);
+#endif /* SWITCHAPI_ENABLE */
+
+#ifdef SWITCHSAI_ENABLE
+#define SWITCH_SAI_THRIFT_RPC_SERVER_PORT "9092"
+extern int start_p4_sai_thrift_rpc_server(char * port);
+#endif /* SWITCHSAI_ENABLE */
+
+
+int
+bmv2_model_init() {
+  int rv=0;
+  /* Start up the PD RPC server */
+  void *pd_server_cookie;
+  start_bfn_pd_rpc_server(&pd_server_cookie);
+  add_to_rpc_server(pd_server_cookie);
+
+  p4_pd_init();
+  p4_pd_dc_init();
+  p4_pd_dc_assign_device(0, "ipc:///tmp/bmv2-0-notifications.ipc", 10001);
+
+  /* Start up the API RPC server */
+#ifdef SWITCHAPI_ENABLE
+  CHECK(switch_api_init(0, 256));
+  CHECK(start_switch_api_rpc_server());
+  CHECK(start_switch_api_packet_driver());
+#endif /* SWITCHAPI_DISABLE */
+
+#ifdef SWITCHSAI_ENABLE
+  CHECK(start_p4_sai_thrift_rpc_server(SWITCH_SAI_THRIFT_RPC_SERVER_PORT));
+#endif /*SWITCHSAI_ENABLE */
+
+#ifdef SWITCHLINK_ENABLE
+  CHECK(switchlink_init());
+#endif /* SWITCHLINK_ENABLE */
+
+  return rv;
+}

--- a/bmv2/main.c
+++ b/bmv2/main.c
@@ -1,0 +1,83 @@
+/*
+Copyright 2013-present Barefoot Networks, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+#include <errno.h>
+#include <stdbool.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+#include <sys/queue.h>
+#include <sys/types.h>
+#include <stdio.h>
+
+#include <getopt.h>
+#include <assert.h>
+
+extern char *pd_server_str;
+extern int bmv2_model_init();
+
+static void
+parse_options(int argc, char **argv)
+{
+  struct entry *np = NULL;
+
+  while (1) {
+    int option_index = 0;
+    /* Options without short equivalents */
+    enum long_opts {
+      OPT_START = 256,
+      OPT_PDSERVER,
+    };
+    static struct option long_options[] = {
+      {"help", no_argument, 0, 'h' },
+      {"pd-server", required_argument, 0, OPT_PDSERVER },
+      {0, 0, 0, 0 }
+    };
+    int c = getopt_long(argc, argv, "h",
+                        long_options, &option_index);
+    if (c == -1) {
+      break;
+    }
+    switch (c) {
+      case OPT_PDSERVER:
+        pd_server_str = strdup(optarg);
+        break;
+      case 'h':
+      case '?':
+        printf("Drivers! \n");
+        printf("Usage: drivers [OPTION]...\n");
+        printf("\n");
+        printf(" --pd-server=IP:PORT Listen for PD RPC calls\n");
+        printf(" -h,--help Display this help message and exit\n");
+        exit(c == 'h' ? 0 : 1);
+        break;
+    }
+  }
+}
+
+int
+main(int argc, char* argv[])
+{
+  int rv = 0;
+
+  parse_options(argc, argv);
+
+  bmv2_model_init();
+
+  while (1) pause();
+
+  return rv;
+}

--- a/bmv2/split_pd_thrift.py
+++ b/bmv2/split_pd_thrift.py
@@ -1,0 +1,53 @@
+#!/usr/bin/env python
+import os
+import subprocess
+import sys
+
+def get_output_file_name(output_dir, output_file_num):
+    return os.path.join(output_dir, 'p4_prefix%d.cpp' % output_file_num)
+
+def split_pd_thrift(input_file_name, output_dir, num_output_files):
+    num_input_lines = int(subprocess.check_output(
+                              'wc -l %s | awk \'{print $1}\'' % input_file_name,
+                              shell=True))
+    for output_file_num in range(num_output_files):
+        output_file_name = get_output_file_name(output_dir, output_file_num)
+        os.system('grep "^#include" %s > %s' % (input_file_name,
+                                                output_file_name))
+        os.system('grep namespace\ p4_pd_rpc %s >> %s' % (input_file_name,
+                                                         output_file_name))
+
+    output_file_num = 0
+    end_namespace = '} // namespace'
+    output_line_num = 0
+    with open(input_file_name) as input_file:
+        for line in input_file:
+            if line == 'namespace p4_pd_rpc {\n':
+                break
+        for line in input_file:
+            if output_line_num == 0 and output_file_num < num_output_files: # {
+                output_file_name = get_output_file_name(output_dir,
+                                                        output_file_num)
+                output_file = open(output_file_name, "a")
+                output_file_num += 1
+            # }
+            output_file.write(line)
+            output_line_num += 1
+            if line == end_namespace:
+                # Reached the end of the namespace (last line in file)
+                break
+            elif (output_line_num > (num_input_lines / num_output_files)) and \
+                 (line == '}\n'): # {
+                # Reached end of function. close the file
+                output_file.write('%s\n' % end_namespace)
+                output_file.close()
+                output_line_num = 0
+            # }
+
+
+if __name__ == '__main__':
+    assert len(sys.argv) == 4
+    input_file_name = sys.argv[1]
+    output_dir = sys.argv[2]
+    num_output_files = sys.argv[3]
+    split_pd_thrift(input_file_name, output_dir, int(num_output_files))

--- a/configure.ac
+++ b/configure.ac
@@ -16,16 +16,31 @@ AC_CONFIG_HEADERS([config.h])
 # Check for thrift support (Apache Thrift RPC library)
 AC_PATH_PROG([THRIFT], [thrift], [])
 AS_IF([test x"$THRIFT" = x], [AC_MSG_ERROR([Missing thrift executable])])
-# Thrift must always be enabled by default. A real check is performed in
-# p4factory/release/pkg-configure.ac.
+# Thrift must always be enabled by default
 AM_CONDITIONAL([IS_THRIFT_ENABLED], [test "x" = "x"])
 
+coverage_enabled=no
 AC_ARG_ENABLE([coverage],
     AS_HELP_STRING([--enable-coverage], [Enable gcov flags]))
 AS_IF([test "x$enable_coverage" = "xyes"], [
+    coverage_enabled=yes
     AC_DEFINE([COVERAGE], [], ["Link with gcov."])
     COVERAGE_FLAGS="--coverage"
 ])
+
+want_bmv2=no
+AC_ARG_WITH([bmv2],
+    AS_HELP_STRING([--with-bmv2], [Build for bmv2 target]),
+    [want_bmv2=yes], [])
+
+AM_CONDITIONAL([WITH_BMV2], [test "$want_bmv2" = yes])
+
+want_p4factory=no
+AC_ARG_WITH([p4factory],
+    AS_HELP_STRING([--with-p4factory], [Build for p4factory target]),
+    [want_p4factory=yes], [])
+
+AM_CONDITIONAL([WITH_P4FACTORY], [test "$want_p4factory" = yes])
 
 AC_PROG_CC_STDC
 AC_PROG_CXX
@@ -33,12 +48,55 @@ LT_INIT
 
 AC_CONFIG_MACRO_DIR([m4])
 
+# will abort if there is no Python interpreter >= 2.7
+AM_PATH_PYTHON([2.7])
+
+AC_PROG_AWK
+AC_PROG_SED
+AC_PROG_GREP
+
 # enforce -std=c++11
 # AX_CXX_COMPILE_STDCXX_11([noext],[mandatory])
 
 # Checks for header files.
 AC_LANG_PUSH(C)
 AC_LANG_PUSH(C++)
+
+# To simplify usage, we will update PATH, CPPFLAGS,.. to include the 'prefix'
+# ones
+adl_RECURSIVE_EVAL([$bindir], [BIN_DIR])
+adl_RECURSIVE_EVAL([$includedir], [INCLUDE_DIR])
+adl_RECURSIVE_EVAL([$pythondir], [PYTHON_DIR])
+adl_RECURSIVE_EVAL([$libdir], [LIB_DIR])
+
+AS_IF([test "$want_bmv2" = yes], [
+    AC_PATH_PROG([P4C_BM], [p4c-bmv2], [], [$PATH$PATH_SEPARATOR$BIN_DIR])
+    AS_IF([test x"$P4C_BM" = x], AC_MSG_ERROR([cannot find p4c-bmv2 compiler]))
+
+    CPPFLAGS="$CPPFLAGS -I$INCLUDE_DIR"
+    AC_CHECK_HEADER([p4c_bm/pdfixed/pd/pd_common.h], [],
+      [AC_MSG_ERROR([bmv2 pdfixed headers not found])])
+
+    # TODO(antonin): this is quite nasty, and in the long term I should probably
+    # adjust the installation path of the p4c_bm products instead, but I don't
+    # want to break too many things at once
+    ab_FIND_HEADER_PATH(["p4c_bm/pdfixed/thrift/res.thrift"], [pdfixed_path])
+    pdfixed_path=`AS_DIRNAME(["$pdfixed_path"])`
+    AC_SUBST([BM_PDFIXED_PATH], ["$pdfixed_path"])
+
+    AC_CHECK_HEADER([bm_sim/Standard.h], [],
+      [AC_MSG_ERROR([bmv2 Thrift headers not found])])
+
+    ab_FIND_HEADER_PATH(["bm_sim/Standard.h"], [bm_thrift_path])
+    AC_SUBST([BM_THRIFT_PATH], ["$bm_thrift_path"])
+
+    # A little extra: check for simple_switch target; of course it is not
+    # critical if we cannot find it
+    AC_PATH_PROG([BM_SIMPLE_SWITCH], [simple_switch], [],
+      [$PATH$PATH_SEPARATOR$BIN_DIR])
+    AS_IF([test x"$BM_SIMPLE_SWITCH" = x],
+      [AC_MSG_WARN([You are compiling for bmv2, but simple_switch binary was not found])])
+])
 
 AC_CHECK_HEADERS([assert.h stdio.h string.h sys/stat.h sys/types.h unistd.h], \
 [], [AC_MSG_ERROR([Missing header file])])
@@ -80,15 +138,22 @@ AC_TYPE_UINT32_T
 AC_TYPE_UINT64_T
 AC_TYPE_UINT8_T
 
-AC_SUBST([AM_CXXFLAGS], ["$TOFINO_FLAGS"])
-AC_SUBST([AM_CPPFLAGS], ["-I$(if test x$prefix != xNONE; then \
-                                echo $prefix; \
-                              else \
-                                echo $ac_default_prefix; \
-                              fi \
-                             )/include"])
+AC_SUBST([AM_CPPFLAGS], ["-I$INCLUDE_DIR"])
+AC_SUBST([AM_LDFLAGS], ["-L$LIB_DIR"])
+AC_SUBST([PYTHONPATH], ["PYTHONPATH=$PYTHONPATH:$PYTHON_DIR"])
+
 # Generate makefiles
-AC_CONFIG_FILES([switchapi/third-party/tommyds/Makefile switchapi/Makefile
-         switchsai/Makefile 
-         switchlink/third-party/xxhash/Makefile switchlink/Makefile Makefile])
+AC_CONFIG_FILES([switchapi/third-party/tommyds/Makefile
+                 switchapi/Makefile
+                 switchsai/Makefile
+                 switchlink/third-party/xxhash/Makefile
+                 switchlink/Makefile
+                 Makefile
+                 bmv2/Makefile])
 AC_OUTPUT
+
+AS_ECHO("")
+AS_ECHO("Features recap ......................")
+AS_ECHO("Coverage enabled .............. : $coverage_enabled")
+AS_ECHO("Compile for p4factory ......... : $want_p4factory")
+AS_ECHO("Compile for bmv2 .............. : $want_bmv2")

--- a/configure.ac
+++ b/configure.ac
@@ -42,6 +42,43 @@ AC_ARG_WITH([p4factory],
 
 AM_CONDITIONAL([WITH_P4FACTORY], [test "$want_p4factory" = yes])
 
+want_switchapi=no
+AC_ARG_WITH([switchapi],
+    AS_HELP_STRING([--with-switchapi], [Build with switchapi]),
+    [want_switchapi=yes], [])
+
+want_switchsai=no
+AC_ARG_WITH([switchsai],
+    AS_HELP_STRING([--with-switchsai],
+                   [Build with switchsai, will build switchapi as well]),
+    [want_switchsai=yes], [])
+
+want_switchlink=no
+AC_ARG_WITH([switchlink],
+    AS_HELP_STRING([--with-switchlink],
+                   [Build with switchlink, will build switchsai and switchapi as well]),
+    [want_switchlink=yes], [])
+
+MY_CPPFLAGS=
+
+AS_IF([test "$want_switchlink" = yes], [
+    want_switchsai=yes
+    MY_CPPFLAGS="$MY_CPPFLAGS -DSWITCHLINK_ENABLE"
+    netlink_libs=$(pkg-config --libs libnl-route-3.0)
+    AC_SUBST([NETLINK_LIBS], ["$netlink_libs"])
+])
+
+AS_IF([test "$want_switchsai" = yes], [
+    want_switchapi=yes
+    MY_CPPFLAGS="$MY_CPPFLAGS -DSWITCHSAI_ENABLE"])
+
+AS_IF([test "$want_switchapi" = yes], [
+    MY_CPPFLAGS="$MY_CPPFLAGS -DSWITCHAPI_ENABLE"])
+
+AM_CONDITIONAL([WITH_SWITCHAPI], [test "$want_switchapi" = yes])
+AM_CONDITIONAL([WITH_SWITCHSAI], [test "$want_switchsai" = yes])
+AM_CONDITIONAL([WITH_SWITCHLINK], [test "$want_switchlink" = yes])
+
 AC_PROG_CC_STDC
 AC_PROG_CXX
 LT_INIT
@@ -114,6 +151,9 @@ if test -n "$COVERAGE_FLAGS"; then
     AC_CHECK_LIB([gcov], [__gcov_init], [], [AC_MSG_ERROR([Missing gcov library])])
 fi
 
+# Check for libJudy
+AC_CHECK_LIB([Judy], [Judy1Next], [], [AC_MSG_ERROR([Missing libJudy])])
+
 # Checks for typedefs, structures, and compiler characteristics.
 AC_CHECK_FUNCS([memset])
 AC_CHECK_FUNCS([select])
@@ -138,7 +178,8 @@ AC_TYPE_UINT32_T
 AC_TYPE_UINT64_T
 AC_TYPE_UINT8_T
 
-AC_SUBST([AM_CPPFLAGS], ["-I$INCLUDE_DIR"])
+MY_CPPFLAGS="$MY_CPPFLAGS -I$INCLUDE_DIR"
+AC_SUBST([AM_CPPFLAGS], ["$MY_CPPFLAGS"])
 AC_SUBST([AM_LDFLAGS], ["-L$LIB_DIR"])
 AC_SUBST([PYTHONPATH], ["PYTHONPATH=$PYTHONPATH:$PYTHON_DIR"])
 
@@ -155,5 +196,8 @@ AC_OUTPUT
 AS_ECHO("")
 AS_ECHO("Features recap ......................")
 AS_ECHO("Coverage enabled .............. : $coverage_enabled")
+AS_ECHO("With switchlink ............... : $want_switchlink")
+AS_ECHO("With switchsai ................ : $want_switchsai")
+AS_ECHO("With switchapi ................ : $want_switchapi")
 AS_ECHO("Compile for p4factory ......... : $want_p4factory")
 AS_ECHO("Compile for bmv2 .............. : $want_bmv2")

--- a/m4/ab_find_header_path.m4
+++ b/m4/ab_find_header_path.m4
@@ -1,0 +1,15 @@
+dnl ab_FIND_HEADER_PATH(HEADER, RESULT)
+dnl =================================
+dnl Find the location of the header file HEADER
+dnl and set the result to $RESULT.
+dnl WARNING: This may not be very robust, but I believe it works with gcc, clang
+AC_DEFUN([ab_FIND_HEADER_PATH],
+  [SAVED_CPPFLAGS="$CPPFLAGS"
+   CPPFLAGS+="$CPPFLAGS -H"
+   AC_PREPROC_IFELSE(
+     [AC_LANG_SOURCE([[#include $1]])],
+     [_ab_tmp_path=$(cat conftest.err | awk 'NR==1' | awk 'END {print $NF}')],
+     [AC_MSG_FAILURE([unexpected preprocessor failure])])
+   CPPFLAGS=$SAVED_CPPFLAGS
+   $2=`AS_DIRNAME(["$_ab_tmp_path"])`]
+)

--- a/m4/adl_recursive_eval.m4
+++ b/m4/adl_recursive_eval.m4
@@ -1,0 +1,15 @@
+dnl adl_RECURSIVE_EVAL(VALUE, RESULT)
+dnl =================================
+dnl Interpolate the VALUE in loop until it doesn't change,
+dnl and set the result to $RESULT.
+dnl WARNING: It's easy to get an infinite loop with some unsane input.
+AC_DEFUN([adl_RECURSIVE_EVAL],
+[_lcl_receval="$1"
+$2=`(test "x$prefix" = xNONE && prefix="$ac_default_prefix"
+     test "x$exec_prefix" = xNONE && exec_prefix="${prefix}"
+     _lcl_receval_old=''
+     while test "[$]_lcl_receval_old" != "[$]_lcl_receval"; do
+       _lcl_receval_old="[$]_lcl_receval"
+       eval _lcl_receval="\"[$]_lcl_receval\""
+     done
+     echo "[$]_lcl_receval")`])

--- a/p4src/p4_files.am
+++ b/p4src/p4_files.am
@@ -1,0 +1,29 @@
+p4_files = \
+$(top_srcdir)/p4src/acl.p4 \
+$(top_srcdir)/p4src/archdeps.p4 \
+$(top_srcdir)/p4src/egress_filter.p4 \
+$(top_srcdir)/p4src/fabric.p4 \
+$(top_srcdir)/p4src/hashes.p4 \
+$(top_srcdir)/p4src/int_transit.p4 \
+$(top_srcdir)/p4src/ipv4.p4 \
+$(top_srcdir)/p4src/ipv6.p4 \
+$(top_srcdir)/p4src/l2.p4 \
+$(top_srcdir)/p4src/l3.p4 \
+$(top_srcdir)/p4src/meter.p4 \
+$(top_srcdir)/p4src/mirror.p4 \
+$(top_srcdir)/p4src/multicast.p4 \
+$(top_srcdir)/p4src/nexthop.p4 \
+$(top_srcdir)/p4src/openflow.p4 \
+$(top_srcdir)/p4src/port.p4 \
+$(top_srcdir)/p4src/rewrite.p4 \
+$(top_srcdir)/p4src/security.p4 \
+$(top_srcdir)/p4src/switch_config.p4 \
+$(top_srcdir)/p4src/switch.p4 \
+$(top_srcdir)/p4src/tunnel.p4 \
+$(top_srcdir)/p4src/includes/defines.p4 \
+$(top_srcdir)/p4src/includes/drop_reasons.h \
+$(top_srcdir)/p4src/includes/headers.p4 \
+$(top_srcdir)/p4src/includes/intrinsic.p4 \
+$(top_srcdir)/p4src/includes/p4features.h \
+$(top_srcdir)/p4src/includes/parser.p4 \
+$(top_srcdir)/p4src/includes/sizes.p4

--- a/switchapi/Makefile.am
+++ b/switchapi/Makefile.am
@@ -139,6 +139,7 @@ libbmswitchapi_la_CPPFLAGS += -I$(BM_PDFIXED_PATH)/
 lib_LTLIBRARIES += libbmswitchapi.la
 libbmswitchapi_la_SOURCES = $(switchapi_sources)
 libbmswitchapi_la_LIBADD = third-party/tommyds/libtommyds.la
+libbmswitchapi_la_LIBADD += -lJudy
 endif
 
 # FIXME: legacy support, relies on p4factory

--- a/switchapi/Makefile.am
+++ b/switchapi/Makefile.am
@@ -2,13 +2,13 @@ ACLOCAL_AMFLAGS = ${ACLOCAL_FLAGS} -I m4
 
 SUBDIRS = third-party/tommyds
 
-libswitchapi_la_CFLAGS = -I$(srcdir)/inc
-libswitchapi_la_CFLAGS += -I$(srcdir)/src/gen-cpp
-libswitchapi_la_CFLAGS += -I$(srcdir)/third-party/tommyds/include
-libswitchapi_la_CFLAGS += -I$(srcdir)/../p4src/include
-libswitchapi_la_CXXFLAGS = $(libswitchapi_la_CFLAGS)
-libswitchapi_a_CFLAGS = $(libswitchapi_la_CFLAGS)
-libswitchapi_a_CXXFLAGS = $(libswitchapi_a_CFLAGS)
+# using AM_CPPFLAGS so it applies to all libraries
+
+AM_CPPFLAGS = -I$(srcdir)/inc
+AM_CPPFLAGS += -I$(builddir)/src/gen-cpp
+AM_CPPFLAGS += -I$(srcdir)/third-party/tommyds/include
+AM_CPPFLAGS += -I$(top_srcdir)/p4src/includes
+AM_CPPFLAGS += -I$(includedir)
 
 BUILT_SOURCES = \
 src/gen-cpp/switch_api_constants.cpp \
@@ -18,13 +18,34 @@ src/gen-cpp/switch_api_rpc.h \
 src/gen-cpp/switch_api_types.cpp \
 src/gen-cpp/switch_api_types.h
 
-$(BUILT_SOURCES): src/switch_api.thrift
-	$(THRIFT) -o $(srcdir)/src/ --gen cpp -r $(srcdir)/src/switch_api.thrift
+# http://www.gnu.org/software/automake/manual/html_node/Multiple-Outputs.html
+switchapi.ts : @srcdir@/src/switch_api.thrift
+	@rm -f switchapi.tmp
+	@touch switchapi.tmp
+	$(THRIFT) -o @builddir@/src/ --gen cpp -r @srcdir@/src/switch_api.thrift
+	$(THRIFT) -o @builddir@/src/ --gen py -r @srcdir@/src/switch_api.thrift
+	@mv -f switchapi.tmp $@
 
-lib_LIBRARIES = libswitchapi.a
-lib_LTLIBRARIES = libswitchapi.la
+$(BUILT_SOURCES): switchapi.ts
+## Recover from the removal of $@
+	@if test -f $@; then :; else \
+	  trap 'rm -rf switchapi.lock switchapi.ts' 1 2 13 15; \
+## mkdir is a portable test-and-set
+	if mkdir switchapi.lock 2>/dev/null; then \
+## This code is being executed by the first process.
+	  rm -f switchapi.ts; \
+	  $(MAKE) $(AM_MAKEFLAGS) switchapi.ts; \
+	  result=$$?; rm -rf switchapi.lock; exit $$result; \
+	else \
+## This code is being executed by the follower processes.
+## Wait until the first process is done.
+	  while test -d switchapi.lock; do sleep 1; done; \
+## Succeed if and only if the first process succeeded.
+	    test -f switchapi.ts; \
+	  fi; \
+	fi
 
-libswitchapi_la_SOURCES = \
+switchapi_sources = \
 $(BUILT_SOURCES) \
 src/switch_acl.c \
 src/switch_acl_int.h \
@@ -107,5 +128,23 @@ inc/switch_vlan.h \
 inc/switch_INT.h \
 inc/switch_vrf.h
 
-libswitchapi_a_SOURCES = $(libswitchapi_la_SOURCES)
-libswitchapi_la_LIBADD = third-party/tommyds/libtommyds.la
+lib_LTLIBRARIES =
+lib_LIBRARIES =
+
+if WITH_BMV2
+libbmswitchapi_la_CPPFLAGS = $(AM_CPPFLAGS)
+libbmswitchapi_la_CPPFLAGS += -DBMV2
+libbmswitchapi_la_CPPFLAGS += -I$(top_srcdir)/bmv2/p4_pd
+libbmswitchapi_la_CPPFLAGS += -I$(BM_PDFIXED_PATH)/
+lib_LTLIBRARIES += libbmswitchapi.la
+libbmswitchapi_la_SOURCES = $(switchapi_sources)
+libbmswitchapi_la_LIBADD = third-party/tommyds/libtommyds.la
+endif
+
+# FIXME: legacy support, relies on p4factory
+if WITH_P4FACTORY
+lib_LIBRARIES += libswitchapi.a
+libswitchapi_a_SOURCES = $(switchapi_sources)
+endif
+
+CLEANFILES = $(BUILT_SOURCES)

--- a/switchapi/Makefile.am
+++ b/switchapi/Makefile.am
@@ -128,7 +128,7 @@ inc/switch_vlan.h \
 inc/switch_INT.h \
 inc/switch_vrf.h
 
-lib_LTLIBRARIES =
+noinst_LTLIBRARIES =
 lib_LIBRARIES =
 
 if WITH_BMV2
@@ -136,7 +136,7 @@ libbmswitchapi_la_CPPFLAGS = $(AM_CPPFLAGS)
 libbmswitchapi_la_CPPFLAGS += -DBMV2
 libbmswitchapi_la_CPPFLAGS += -I$(top_srcdir)/bmv2/p4_pd
 libbmswitchapi_la_CPPFLAGS += -I$(BM_PDFIXED_PATH)/
-lib_LTLIBRARIES += libbmswitchapi.la
+noinst_LTLIBRARIES += libbmswitchapi.la
 libbmswitchapi_la_SOURCES = $(switchapi_sources)
 libbmswitchapi_la_LIBADD = third-party/tommyds/libtommyds.la
 libbmswitchapi_la_LIBADD += -lJudy

--- a/switchapi/inc/switchapi/switch_base_types.h
+++ b/switchapi/inc/switchapi/switch_base_types.h
@@ -23,7 +23,6 @@ limitations under the License.
 #include "p4features.h"
 #include "drop_reasons.h"
 #include "p4features.h"
-#include "model_flags.h"
 #ifdef BMV2
 #include "pd/pd.h"
 #include "pd/pd_pre.h"

--- a/switchapi/inc/switchapi/switch_mirror.h
+++ b/switchapi/inc/switchapi/switch_mirror.h
@@ -20,7 +20,6 @@ limitations under the License.
 #include "switch_base_types.h"
 #include "switch_handle.h"
 #include "switch_tunnel.h"
-#include "model_flags.h"
 #ifdef BMV2
 #include "pd/pd_mirroring.h"
 #else

--- a/switchapi/src/switch_pd.c
+++ b/switchapi/src/switch_pd.c
@@ -23,7 +23,6 @@ limitations under the License.
 #include "switch_mirror_int.h"
 #include "switch_tunnel_int.h"
 #include "switch_config_int.h"
-#include "model_flags.h"
 #include <string.h>
 
 #define ingress_input_port standard_metadata_ingress_port

--- a/switchlink/Makefile.am
+++ b/switchlink/Makefile.am
@@ -29,14 +29,14 @@ src/switchlink_route.h \
 src/switchlink_sai.c \
 src/switchlink_sai.h
 
-lib_LTLIBRARIES =
+noinst_LTLIBRARIES =
 lib_LIBRARIES =
 
 if WITH_BMV2
 # has the advantage of avoiding "created both with libtool and without" error
 libswitchlink_la_CPPFLAGS = $(AM_CPPFLAGS)
 libswitchlink_la_CPPFLAGS += -DBMV2
-lib_LTLIBRARIES += libswitchlink.la
+noinst_LTLIBRARIES += libswitchlink.la
 libswitchlink_la_SOURCES = $(switchlink_sources)
 libswitchlink_la_LIBADD = third-party/xxhash/libxxhash.la
 libswitchlink_la_LIBADD += $(NETLINK_LIBS)

--- a/switchlink/Makefile.am
+++ b/switchlink/Makefile.am
@@ -39,6 +39,7 @@ libswitchlink_la_CPPFLAGS += -DBMV2
 lib_LTLIBRARIES += libswitchlink.la
 libswitchlink_la_SOURCES = $(switchlink_sources)
 libswitchlink_la_LIBADD = third-party/xxhash/libxxhash.la
+libswitchlink_la_LIBADD += $(NETLINK_LIBS)
 endif
 
 # FIXME: legacy support, relies on p4factory

--- a/switchlink/Makefile.am
+++ b/switchlink/Makefile.am
@@ -2,16 +2,13 @@ ACLOCAL_AMFLAGS = ${ACLOCAL_FLAGS} -I m4
 
 SUBDIRS = third-party/xxhash
 
-libswitchlink_la_CFLAGS  = -I$(srcdir)/third-party/xxhash/include
-libswitchlink_la_CFLAGS += -I$(SUBMODULE_SWITCHSAI)/submodules/SAI/inc
-libswitchlink_la_CFLAGS += -I$(SUBMODULE_SWITCHAPI)/third-party/tommyds/include
-libswitchlink_la_CFLAGS += $(shell pkg-config --cflags libnl-3.0)
-libswitchlink_a_CFLAGS = $(libswitchlink_la_CFLAGS)
+AM_CPPFLAGS = -I$(srcdir)/third-party/xxhash/include
+AM_CPPFLAGS += -I$(top_srcdir)/switchsai/submodules/SAI/inc
+AM_CPPFLAGS += -I$(top_srcdir)/switchapi/third-party/tommyds/include
+# TODO: could this be done in configure?
+AM_CPPFLAGS += $(shell pkg-config --cflags libnl-3.0)
 
-lib_LIBRARIES = libswitchlink.a
-lib_LTLIBRARIES = libswitchlink.la
-
-libswitchlink_la_SOURCES = \
+switchlink_sources = \
 src/switchlink_address.c \
 src/switchlink_db.c \
 src/switchlink_db.h \
@@ -32,9 +29,24 @@ src/switchlink_route.h \
 src/switchlink_sai.c \
 src/switchlink_sai.h
 
-libswitchlink_a_SOURCES = $(libswitchlink_la_SOURCES)
+lib_LTLIBRARIES =
+lib_LIBRARIES =
 
+if WITH_BMV2
+# has the advantage of avoiding "created both with libtool and without" error
+libswitchlink_la_CPPFLAGS = $(AM_CPPFLAGS)
+libswitchlink_la_CPPFLAGS += -DBMV2
+lib_LTLIBRARIES += libswitchlink.la
+libswitchlink_la_SOURCES = $(switchlink_sources)
 libswitchlink_la_LIBADD = third-party/xxhash/libxxhash.la
+endif
 
+# FIXME: legacy support, relies on p4factory
+if WITH_P4FACTORY
+lib_LIBRARIES += libswitchlink.a
+libswitchlink_a_SOURCES = $(switchlink_sources)
+endif
+
+# FIXME: dos this really serve a purpose?
 switch-local: all
 switch-install-local: install

--- a/switchsai/Makefile.am
+++ b/switchsai/Makefile.am
@@ -79,7 +79,7 @@ src/saiutils.c \
 src/saivlan.c \
 src/switch_sai_rpc_server.cpp
 
-lib_LTLIBRARIES =
+noinst_LTLIBRARIES =
 lib_LIBRARIES =
 
 if WITH_BMV2
@@ -87,7 +87,7 @@ libbmswitchsai_la_CPPFLAGS = $(AM_CPPFLAGS)
 libbmswitchsai_la_CPPFLAGS += -DBMV2
 libbmswitchsai_la_CPPFLAGS += -I$(top_srcdir)/bmv2/p4_pd
 libbmswitchsai_la_CPPFLAGS += -I$(BM_PDFIXED_PATH)
-lib_LTLIBRARIES += libbmswitchsai.la
+noinst_LTLIBRARIES += libbmswitchsai.la
 libbmswitchsai_la_SOURCES = $(switchsai_sources)
 endif
 

--- a/switchsai/Makefile.am
+++ b/switchsai/Makefile.am
@@ -1,13 +1,10 @@
 ACLOCAL_AMFLAGS = ${ACLOCAL_FLAGS} -I m4
 
-libswitchsai_la_CFLAGS  = -I$(srcdir)/submodules/SAI/inc
-libswitchsai_la_CFLAGS += -I$(srcdir)/../../modules/BMI/module/inc
-libswitchsai_la_CFLAGS += -I$(builddir)/src/gen-cpp
-libswitchsai_la_CFLAGS += -I$(top_srcdir)/switchapi/third-party/tommyds/include
-libswitchsai_la_CFLAGS += -I$(top_srcdir)/p4src/includes
-libswitchsai_la_CXXFLAGS = $(libswitchsai_la_CFLAGS)
-libswitchsai_a_CFLAGS = $(libswitchsai_la_CFLAGS)
-libswitchsai_a_CXXFLAGS = $(libswitchsai_a_CFLAGS)
+AM_CPPFLAGS = -I$(srcdir)/submodules/SAI/inc
+AM_CPPFLAGS += -I$(top_srcdir)/switchapi/inc
+AM_CPPFLAGS += -I$(builddir)/src/gen-cpp
+AM_CPPFLAGS += -I$(top_srcdir)/switchapi/third-party/tommyds/include
+AM_CPPFLAGS += -I$(top_srcdir)/p4src/includes
 
 thrift_cpp_sources = \
 @builddir@/src/gen-cpp/switch_sai_constants.cpp \
@@ -22,41 +19,6 @@ thrift_py_sources = \
 @builddir@/src/gen-py/switch_sai/switch_sai_rpc.py \
 @builddir@/src/gen-py/switch_sai/switch_sai_rpc-remote \
 @builddir@/src/gen-py/switch_sai/ttypes.py
-
-lib_LIBRARIES = libswitchsai.a
-lib_LTLIBRARIES = libswitchsai.la
-
-$(lib_LIBRARIES) : $(thrift_py_sources)
-$(lib_LTLIBRARIES) : $(thrift_py_sources)
-
-libswitchsai_la_SOURCES = \
-$(thrift_cpp_sources) \
-src/saiacl.c \
-src/saiapi.h \
-src/sai.c \
-src/sai_bmlib.c \
-src/saifdb.c \
-src/saihostintf.c \
-src/saiinternal.h \
-src/saiipmc.c \
-src/sail2mc.c \
-src/sailag.c \
-src/saimirror.c \
-src/saineighbor.c \
-src/sainexthop.c \
-src/sainexthopgroup.c \
-src/saipolicer.c \
-src/saiport.c \
-src/sairoute.c \
-src/sairouter.c \
-src/sairouterintf.c \
-src/saistp.c \
-src/saiswitch.c \
-src/saiutils.c \
-src/saivlan.c \
-src/switch_sai_rpc_server.cpp
-
-libswitchsai_a_SOURCES = $(libswitchsai_la_SOURCES)
 
 BUILT_SOURCES = \
 $(thrift_cpp_sources) \
@@ -89,5 +51,53 @@ $(BUILT_SOURCES) : switchsai.ts
 	    test -f switchsai.ts; \
 	  fi; \
 	fi
+
+switchsai_sources = \
+$(thrift_cpp_sources) \
+src/saiacl.c \
+src/saiapi.h \
+src/sai.c \
+src/sai_bmlib.c \
+src/saifdb.c \
+src/saihostintf.c \
+src/saiinternal.h \
+src/saiipmc.c \
+src/sail2mc.c \
+src/sailag.c \
+src/saimirror.c \
+src/saineighbor.c \
+src/sainexthop.c \
+src/sainexthopgroup.c \
+src/saipolicer.c \
+src/saiport.c \
+src/sairoute.c \
+src/sairouter.c \
+src/sairouterintf.c \
+src/saistp.c \
+src/saiswitch.c \
+src/saiutils.c \
+src/saivlan.c \
+src/switch_sai_rpc_server.cpp
+
+lib_LTLIBRARIES =
+lib_LIBRARIES =
+
+if WITH_BMV2
+libbmswitchsai_la_CPPFLAGS = $(AM_CPPFLAGS)
+libbmswitchsai_la_CPPFLAGS += -DBMV2
+libbmswitchsai_la_CPPFLAGS += -I$(top_srcdir)/bmv2/p4_pd
+libbmswitchsai_la_CPPFLAGS += -I$(BM_PDFIXED_PATH)
+lib_LTLIBRARIES += libbmswitchsai.la
+libbmswitchsai_la_SOURCES = $(switchsai_sources)
+endif
+
+# FIXME: legacy support, relies on p4factory
+if WITH_P4FACTORY
+lib_LIBRARIES += libswitchsai.a
+libswitchsai_a_SOURCES = $(switchsai_sources)
+endif
+
+# FIXME: not sure if this serves a real purpose
+$(lib_LTLIBRARIES) : $(thrift_py_sources)
 
 CLEANFILES = $(BUILT_SOURCES)


### PR DESCRIPTION
The idea is to be able to use all of the switch products (and run the tests) without p4factory, assuming bmv2 and p4c-bmv2 have been installed. This pull request enables this.
`./configure --with-bmv2` will enable stand-alone compilation of the driver stack
`./configure --with-p4factory` will enable legacy mode
Note that both are compatible (you can provide both flags).
Once this PR is accepted, I will make sure that every thing required to run the switch tests is included in the repository (assuming PTF is installed, which still needs to be taken care of).
Once this PR is accepted, I will update the submodule ref pointers in p4factory (changes are pending in a branch).