### PR TITLE
added support for new PD files pd_registers.[h/cpp]

### DIFF
--- a/bmv2/Makefile.am
+++ b/bmv2/Makefile.am
@@ -5,6 +5,7 @@ p4_pd/src/pd.cpp \
 p4_pd/src/pd_learning.cpp \
 p4_pd/src/pd_meters.cpp \
 p4_pd/src/pd_counters.cpp \
+p4_pd/src/pd_registers.cpp \
 p4_pd/src/pd_tables.cpp \
 p4_pd/src/pd_ageing.cpp \
 p4_pd/src/pd_mirroring.cpp
@@ -14,6 +15,7 @@ p4_pd/pd/pd.h \
 p4_pd/pd/pd_learning.h \
 p4_pd/pd/pd_meters.h \
 p4_pd/pd/pd_counters.h \
+p4_pd/pd/pd_registers.h \
 p4_pd/pd/pd_tables.h \
 p4_pd/pd/pd_types.h \
 p4_pd/pd/pd_mirroring.h


### PR DESCRIPTION
some register support has been added to bmv2 PD; this adds the new files to the appropriate Makefile