### PR TITLE
Removed extraneous transitions in Geneve parser

### DIFF
--- a/p4src/includes/parser.p4
+++ b/p4src/includes/parser.p4
@@ -661,9 +661,6 @@ parser parse_geneve {
                  INGRESS_TUNNEL_TYPE_GENEVE);
     return select(genv.ver, genv.optLen, genv.protoType) {
         ETHERTYPE_ETHERNET : parse_inner_ethernet;
-        ETHERTYPE_IPV4 : parse_inner_ipv4;
-        ETHERTYPE_IPV6 : parse_inner_ipv6;
-        default : ingress;
     }
 }
 


### PR DESCRIPTION
According to Milad (milad14000), Geneve packets should always have an
inner Ethernet header. Bare-IP-in-Geneve is not supported.