### PR TITLE
Removed nop action from fabric_ingress_dst_lkp

### DIFF
--- a/p4src/fabric.p4
+++ b/p4src/fabric.p4
@@ -107,7 +107,6 @@ table fabric_ingress_dst_lkp {
         fabric_header.dstDevice : exact;
     }
     actions {
-        nop;
         terminate_cpu_packet;
 #ifdef FABRIC_ENABLE
         switch_fabric_unicast_packet;


### PR DESCRIPTION
According to Milad (milad14000), this table should never nop.