### PR TITLE
In run_bm.sh, move positional parameter (JSON) to front

### DIFF
--- a/bmv2/run_bm.sh.in
+++ b/bmv2/run_bm.sh.in
@@ -13,4 +13,4 @@ if [ ! -f $JSON_FILE ]; then
     echo "switch.json not found; did you run 'make'?"
     exit 1
 fi
-@BM_SIMPLE_SWITCH@ --log-console -i 0@veth0 -i 1@veth2 -i 2@veth4 -i 3@veth6 -i 4@veth8 -i 5@veth10 -i 6@veth12 -i 7@veth14 -i 8@veth16 -i 64@veth250 --thrift-port 10001 --pcap $JSON_FILE
+@BM_SIMPLE_SWITCH@ $JSON_FILE --log-console -i 0@veth0 -i 1@veth2 -i 2@veth4 -i 3@veth6 -i 4@veth8 -i 5@veth10 -i 6@veth12 -i 7@veth14 -i 8@veth16 -i 64@veth250 --thrift-port 10001 --pcap


### PR DESCRIPTION
Now that --pcap takes an optional directory, we cannot provide the JSON path just after --pcap or it confuses the option parser.